### PR TITLE
feat: API接続先を環境変数化 #14

### DIFF
--- a/frontend/src/app/lib/api.ts
+++ b/frontend/src/app/lib/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:8000';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
 export interface FileInput {
   filename: string;


### PR DESCRIPTION
## 概要
フロントエンドのAPI接続先を環境変数化し、デプロイに対応

## 変更内容
- api.tsのAPI_URLを環境変数（NEXT_PUBLIC_API_URL）から読むように変更
- 環境変数がなければlocalhost:8000にフォールバック
- ローカル開発と本番で接続先を自動切り替え可能に