### PR TITLE
fix: 本番フロントのURLをCORS許可に追加 #14

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,10 @@ app = FastAPI(title="AI Code Review SaaS")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=[
+        "http://localhost:3000",
+        "https://ai-code-review-saas.vercel.app",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 概要
本番デプロイ後にCORSエラーで解析が失敗したため、Vercelの本番URLを許可オリジンに追加

## 変更内容
- main.pyのCORS設定にhttps://ai-code-review-saas.vercel.appを追加